### PR TITLE
Fix object syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ class ExampleComponent extends React.Component {
 
     render() {
         const options = {
-            onChange: this.handleIntersection
-            root: "#scrolling-container"
+            onChange: this.handleIntersection,
+            root: "#scrolling-container",
             rootMargin: "0% 0% -25%"
         };
 


### PR DESCRIPTION
The `options` object needs commas to be proper JavaScript.