### PR TITLE
tweak parseRootMargin util method

### DIFF
--- a/src/__tests__/__snapshots__/utils.spec.js.snap
+++ b/src/__tests__/__snapshots__/utils.spec.js.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parseRootMargin throws when using wrong type 1`] = `"rootMargin must be a String"`;
+
+exports[`parseRootMargin throws when using wrong type 2`] = `"rootMargin must be a String"`;
+
 exports[`parseRootMargin throws when using wrong units 1`] = `"rootMargin must be specified in pixels or percent"`;
 
 exports[`parseRootMargin throws when using wrong units 2`] = `"rootMargin must be specified in pixels or percent"`;

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -17,6 +17,11 @@ describe('isDOMTypeElement', () => {
 });
 
 describe('parseRootMargin', () => {
+    test('throws when using wrong type', () => {
+        expect(() => parseRootMargin(null)).toThrowErrorMatchingSnapshot();
+        expect(() => parseRootMargin(10)).toThrowErrorMatchingSnapshot();
+    });
+
     test('throws when using wrong units', () => {
         expect(() => parseRootMargin('10')).toThrowErrorMatchingSnapshot();
         expect(() => parseRootMargin('10% 10')).toThrowErrorMatchingSnapshot();
@@ -24,8 +29,10 @@ describe('parseRootMargin', () => {
 
     test('returns rootMargins with all four values', () => {
         expect(parseRootMargin()).toBe('0px 0px 0px 0px');
-        expect(parseRootMargin('')).toBe('0px 0px 0px 0px');
-        expect(parseRootMargin('10px 5px 0%')).toBe('10px 5px 0% 5px');
+        expect(parseRootMargin('10px  ')).toBe('10px 10px 10px 10px');
+        expect(parseRootMargin(' 10px 5px')).toBe('10px 5px 10px 5px');
+        expect(parseRootMargin('10px 5px 0% ')).toBe('10px 5px 0% 5px');
+        expect(parseRootMargin('  10px 5px 0% 1%')).toBe('10px 5px 0% 1%');
     });
 });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ export function parseRootMargin(rootMargin = '0px') {
     }
     
     // Handles shorthand.
-    const [m0, m1 = m0, m2 = m0, m3 = m0] = marginString.trim().split(/\s+/).map(margin => {
+    const [m0 = '0px', m1 = m0, m2 = m0, m3 = m0] = marginString.trim().split(/\s+/).map(margin => {
         if (!marginRE.test(margin)) {
             throw new Error('rootMargin must be specified in pixels or percent');
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ export function parseRootMargin(rootMargin = '0px') {
     }
     
     // Handles shorthand.
-    const [m0 = '0px', m1 = m0, m2 = m0, m3 = m0] = marginString.trim().split(/\s+/).map(margin => {
+    const [m0 = '0px', m1 = m0, m2 = m0, m3 = m0] = rootMargin.trim().split(/\s+/).map(margin => {
         if (!marginRE.test(margin)) {
             throw new Error('rootMargin must be specified in pixels or percent');
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,14 +10,17 @@ export function parseRootMargin(rootMargin = '0px') {
     if (typeof rootMargin !== 'string') {
         throw new Error('rootMargin must be a String');
     }
-    
+
     // Handles shorthand.
-    const [m0 = '0px', m1 = m0, m2 = m0, m3 = m0] = rootMargin.trim().split(/\s+/).map(margin => {
-        if (!marginRE.test(margin)) {
-            throw new Error('rootMargin must be specified in pixels or percent');
-        }
-        return margin;
-    });
+    const [m0 = '0px', m1 = m0, m2 = m0, m3 = m1] = rootMargin
+        .trim()
+        .split(/\s+/)
+        .map(margin => {
+            if (!marginRE.test(margin)) {
+                throw new Error('rootMargin must be specified in pixels or percent');
+            }
+            return margin;
+        });
 
     return `${m0} ${m1} ${m2} ${m3}`;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,22 +4,22 @@ export function isDOMTypeElement(element) {
     return React.isValidElement(element) && typeof element.type === 'string';
 }
 
-export function parseRootMargin(rootMargin) {
-    const marginString = rootMargin || '0px';
-    const re = /^-?\d*\.?\d+(px|%)$/;
-    const margins = marginString.split(/\s+/).map(margin => {
-        if (!re.test(margin)) {
+const marginRE = /^-?\d*\.?\d+(px|%)$/;
+
+export function parseRootMargin(rootMargin = '0px') {
+    if (typeof rootMargin !== 'string') {
+        throw new Error('rootMargin must be a String');
+    }
+    
+    // Handles shorthand.
+    const [m0, m1 = m0, m2 = m0, m3 = m0] = marginString.trim().split(/\s+/).map(margin => {
+        if (!marginRE.test(margin)) {
             throw new Error('rootMargin must be specified in pixels or percent');
         }
         return margin;
     });
 
-    // Handles shorthand.
-    margins[1] = margins[1] || margins[0];
-    margins[2] = margins[2] || margins[0];
-    margins[3] = margins[3] || margins[1];
-
-    return margins.join(' ');
+    return `${m0} ${m1} ${m2} ${m3}`;
 }
 
 export function shallowCompareOptions(next, prev) {


### PR DESCRIPTION
## Description
This change to `parseRootMargin` in `utils.js` achieves few things:
1. provides default margin value, if omitted, instead of when falsy
2. type-checks `rootMargin`
3. trims the incoming string first, to handle strings like `' 0px'` properly
4. caches the `RegExp` outside of function scope, not to create on every function call
5. uses destrucuting with default value to "simplify" handling shortcut

<!--- Describe your changes in detail -->

## Motivation and context
I skimmed through the code and saw an opportunity for improvement
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
`jest`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed