### PR TITLE
Bugfix: element.target is undefined

### DIFF
--- a/src/IntersectionObserver.js
+++ b/src/IntersectionObserver.js
@@ -129,7 +129,7 @@ export default class IntersectionObserver extends React.Component {
     };
 
     observe() {
-        this.target = isDOMTypeElement(this.target) ? this.target : findDOMNode(this.target);
+        this.target = isDOMTypeElement(this.target) ? this.target : this.target ? findDOMNode(this.target) : findDOMNode(this);
         this.observer = IntersectionObserverContainer.create(callback, this.options);
         IntersectionObserverContainer.observe(this);
     }


### PR DESCRIPTION
Thanks for taking the time to file a pull request with us.
Please take a moment to provide the following details:

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and context
If you have some item you are observing, and you add & remove it from Dom *on button click for eg), reobserve get called, but this.target is sometimes null as the ref isn't present yet. So, even though we do ```findDOMNode(this.target) ``` in  ```IntersectionObserver.observe()``` , this.target is still null. changed it to do findDomNode(this), if this.target is not found. 

This is the stacktrace of the error that this prevents:

```
Uncaught TypeError: Failed to execute 'observe' on 'IntersectionObserver': parameter 1 is not of type 'Element'.
    at Function.observe (IntersectionObserverContainer.js:91)
    at IntersectionObserver.observe (VM161176 IntersectionObserver.js:86)
    at IntersectionObserver.reobserve (VM161176 IntersectionObserver.js:96)
    at IntersectionObserver.componentDidUpdate (VM161176 IntersectionObserver.js:116)
    at measureLifeCyclePerf (vendor.js:43253)
    at vendor.js:43906
    at CallbackQueue.notifyAll (vendor.js:14619)
    at ReactReconcileTransaction.close (vendor.js:45399)
    at ReactReconcileTransaction.closeAll (vendor.js:8969)
    at ReactReconcileTransaction.perform (vendor.js:8916)

 ```

## How has this been tested?
Tested by adding & removing the parent (+ observed children) from the Dom

## Screenshots (if relevant):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed