### PR TITLE
Update the URL for w3c polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Single React component or element that is used as the target (observable).
 
 ## Polyfill
 
-When needing the full spec's support, we highly recommend using the [IntersectionObserver polyfill](https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill).
+When needing the full spec's support, we highly recommend using the [IntersectionObserver polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill).
 
 ### Caveats
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This project links to the polyfill `IntersectionObserver`. Few months ago, the housing repository for that polyfill changes, so I'm updating the README file here to point to the current GitHub home for the  polyfill

<!--- Describe your changes in detail -->

## Motivation and context
The original repository https://github.com/WICG now forwards to https://github.com/w3c, but the deep link does not work because the branch also changed from `gh-pages` to `master`

## How has this been tested?
N/A
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if relevant):
N/A

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed