### PR TITLE
chore(onlyOnceDeprecation): Deprecate prop onlyOnce

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 
 > Bring ReactIntersectionObserver over today, your React children will love it!
 
-**React Intersection Observer** is a **React** component, acting as a wrapper for the **IntersectionObserver API**. It is fully declarative and takes care of all the imperative parts for you.
+**React Intersection Observer** is a **React** component, acting as a wrapper for the **IntersectionObserver API**. It
+is fully declarative and takes care of all the imperative parts for you.
 
 **React Intersection Observer** is good at:
 
@@ -30,12 +31,12 @@
 
 * [What does IntersectionObserver do?](#what-does-intersectionobserver-do)
 * [Getting started](#getting-started)
-  + [Installation](#installation)
-  + [Inside your codebase](#inside-your-codebase)
+  * [Installation](#installation)
+  * [Inside your codebase](#inside-your-codebase)
 * [Why ReactIntersectionObserver?](#why-reactintersectionobserver)
-  + [No bookkeeping](#no-bookkeeping)
-  + [No extra markup](#no-extra-markup)
-  + [Easy to adopt](#easy-to-adopt)
+  * [No bookkeeping](#no-bookkeeping)
+  * [No extra markup](#no-extra-markup)
+  * [Easy to adopt](#easy-to-adopt)
 * [Documentation](#documentation)
 * [Options](#options)
 * [Notes](#notes)
@@ -43,16 +44,18 @@
 * [IntersectionObserver's Browser Support](#intersectionobservers-browser-support)
 * [Contributing](#contributing)
 * [License](#license)
-</details>
+  </details>
 
 ---
 
 ## What does IntersectionObserver do?
 
-> IntersectionObservers calculate how much of a target element overlaps (or "intersects with") the visible portion of a page, also known as the browser's "viewport":
+> IntersectionObservers calculate how much of a target element overlaps (or "intersects with") the visible portion of a
+> page, also known as the browser's "viewport":
 >
-> \- [Dan Callahan](https://hacks.mozilla.org/2017/08/intersection-observer-comes-to-firefox/)&nbsp;&middot;&nbsp;<a href="https://creativecommons.org/licenses/by-sa/3.0/">
-<img id="licensebutton_slim" alt="Creative Commons License" src="https://i.creativecommons.org/l/by-sa/3.0/80x15.png" style="margin-right:10px;margin-bottom:4px; border: 0;"></a>
+> \- >
+> [Dan Callahan](https://hacks.mozilla.org/2017/08/intersection-observer-comes-to-firefox/)&nbsp;&middot;&nbsp;<a href="https://creativecommons.org/licenses/by-sa/3.0/"> >
+> <img id="licensebutton_slim" alt="Creative Commons License" src="https://i.creativecommons.org/l/by-sa/3.0/80x15.png" style="margin-right:10px;margin-bottom:4px; border: 0;"></a>
 
 ![Graphic example](https://hacks.mozilla.org/files/2017/08/Blank-Diagram-Page-1.png)
 
@@ -83,16 +86,14 @@ class ExampleComponent extends React.Component {
     render() {
         const options = {
             onChange: this.handleIntersection,
-            root: "#scrolling-container",
-            rootMargin: "0% 0% -25%"
+            root: '#scrolling-container',
+            rootMargin: '0% 0% -25%',
         };
 
         return (
             <div id="scrolling-container" style={{ overflow: 'scroll', height: 100 }}>
                 <Observer {...options}>
-                    <div>
-                        I am the target element
-                    </div>
+                    <div>I am the target element</div>
                 </Observer>
             </div>
         );
@@ -102,21 +103,32 @@ class ExampleComponent extends React.Component {
 
 ## Why ReactIntersectionObserver?
 
-The motivation is to provide the easiest possible solution for observing elements that enter the viewport on your **React** codebase. It's fully declarative and all complexity is abstracted away, focusing on reusability, and low memory consumption.
+The motivation is to provide the easiest possible solution for observing elements that enter the viewport on your
+**React** codebase. It's fully declarative and all complexity is abstracted away, focusing on reusability, and low
+memory consumption.
 
 ### No bookkeeping
 
-It's built with compatibility in mind, adhering 100% to the [native API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Intersection_observer_options) implementation and DSL, but takes care of all the bookkeeping work for you.
+It's built with compatibility in mind, adhering 100% to the
+[native API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Intersection_observer_options)
+implementation and DSL, but takes care of all the bookkeeping work for you.
 
-Instances and nodes are managed internally so that any changes to the passed options or tree root reconciliation cleans up and re-observes nodes on-demand to avoid any unexpected memory leaks.
+Instances and nodes are managed internally so that any changes to the passed options or tree root reconciliation cleans
+up and re-observes nodes on-demand to avoid any unexpected memory leaks.
 
 ### No extra markup
 
-ReactIntersectionObserver does not create any extra DOM elements, it attaches to the only child you'll provide to it. Internally it warns you if attaching a `ref` to it fails - common mistake when using a stateless component in React 15 - and will invoke any existing `ref` callback upon the passed child element.
+ReactIntersectionObserver does not create any extra DOM elements, it attaches to the only child you'll provide to it.
+Internally it warns you if attaching a `ref` to it fails - common mistake when using a stateless component in React 15 -
+and will invoke any existing `ref` callback upon the passed child element.
 
 ### Easy to adopt
 
-When using ReactIntersectionObserver the only required prop is the `onChange` function. Any changes to the visibility of the element will invoke this callback, just like in the [native API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Targeting_an_element_to_be_observed) - you’ll receive one `IntersectionObserverEntry` argument per change. This gives you an ideal and flexible base to build upon.
+When using ReactIntersectionObserver the only required prop is the `onChange` function. Any changes to the visibility of
+the element will invoke this callback, just like in the
+[native API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Targeting_an_element_to_be_observed) -
+you’ll receive one `IntersectionObserverEntry` argument per change. This gives you an ideal and flexible base to build
+upon.
 
 Some of the things you may want to use ReactIntersectionObserver for:
 
@@ -129,13 +141,16 @@ Some of the things you may want to use ReactIntersectionObserver for:
 
 ### Demos
 
-Find multiple examples and usage guidelines under: [https://researchgate.github.io/react-intersection-observer/](https://researchgate.github.io/react-intersection-observer/)
+Find multiple examples and usage guidelines under:
+[https://researchgate.github.io/react-intersection-observer/](https://researchgate.github.io/react-intersection-observer/)
 
 [![demo](https://github.com/researchgate/react-intersection-observer/blob/master/.github/demo.gif?raw=true)](https://researchgate.github.io/react-intersection-observer/)
 
 ### Recipes
 
-Recipes are useful code snippets solutions to common problems, for example, how to use ReactIntersectionObserver within a [Higher Order Component](https://researchgate.github.io/react-intersection-observer/?selectedKind=Recipes&selectedStory=Higher%20Order%20Component).
+Recipes are useful code snippets solutions to common problems, for example, how to use ReactIntersectionObserver within
+a
+[Higher Order Component](https://researchgate.github.io/react-intersection-observer/?selectedKind=Recipes&selectedStory=Higher%20Order%20Component).
 
 Discover more recipes in our [examples section](docs/README.md).
 
@@ -151,17 +166,16 @@ Margin around the root. Specify using units _px_ or _%_ (top, right, bottom left
 
 **threshold**: `number|Array<number>` | default: `0`
 
-Indicates at what percentage of the target's visibility the observer's callback should be executed. If you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. If you want the callback run every time visibility passes another 25%, you would specify the array [0, 0.25, 0.5, 0.75, 1].
-
-**onlyOnce**: `boolean` | default: `false`
-
-When true indicate that events fire only until the element is intersecting. Requires `IntersectionObserverEntry`'s object to contain `isIntersecting` in its prototype.
+Indicates at what percentage of the target's visibility the observer's callback should be executed. If you only want to
+detect when visibility passes the 50% mark, you can use a value of 0.5. If you want the callback run every time
+visibility passes another 25%, you would specify the array [0, 0.25, 0.5, 0.75, 1].
 
 **disabled**: `boolean` | default: `false`
 
-Controls whether the element should stop being observed by its IntersectionObserver instance. Useful for temporarily disabling the observing mechanism and restoring it later.
+Controls whether the element should stop being observed by its IntersectionObserver instance. Useful for temporarily
+disabling the observing mechanism and restoring it later.
 
-**onChange** (required): `(entry: IntersectionObserverEntry) => void`
+**onChange** (required): `(entry: IntersectionObserverEntry, unobserve: () => void) => void`
 
 Function that will be invoked whenever an observer's callback contains this target in its changes.
 
@@ -172,29 +186,37 @@ Single React component or element that is used as the target (observable).
 ### Notes
 
 * According to the spec, an initial event is being fired when starting to observe a non-intersecting element as well.
-  * _Edge's implementation seems to [miss the initial event](https://github.com/w3c/IntersectionObserver/issues/222#issuecomment-311539591), although Edge 16 behavior aligns with the spec._
+  * _Edge's implementation seems to
+    [miss the initial event](https://github.com/w3c/IntersectionObserver/issues/222#issuecomment-311539591), although
+    Edge 16 behavior aligns with the spec._
 * Changes happen asynchronously, similar to the way `requestIdleCallback` works.
-* Although you can consider callbacks immediate - always below 1 second - you can also get an immediate response on an element's visibility with `observer.takeRecords()`.
-* The primitives _Map_, _Set_, and _Symbol_ are required and won't be transpiled by default. Consider using a polyfill for browsers lacking ES2015 support. If you're using babel, include `"babel-polyfill"` somewhere to your codebase.
+* Although you can consider callbacks immediate - always below 1 second - you can also get an immediate response on an
+  element's visibility with `observer.takeRecords()`.
+* The primitives _Map_, _Set_, and _Symbol_ are required and won't be transpiled by default. Consider using a polyfill
+  for browsers lacking ES2015 support. If you're using babel, include `"babel-polyfill"` somewhere to your codebase.
 
 ## Polyfill
 
-When needing the full spec's support, we highly recommend using the [IntersectionObserver polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill).
+When needing the full spec's support, we highly recommend using the
+[IntersectionObserver polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill).
 
 ### Caveats
 
 #### Ealier Spec
 
-Earlier preview versions of [Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12156111/) and prior to version 58 of [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=713819#c8), the support for `isIntersecting` was lacking. This property was added to the spec later and both teams where unable to implement it earlier.
-
-If you are using the prop `onlyOnce` or you need this field within your `IntersectionObserverEntry` instances, make sure to [require the version ^0.4.0](https://github.com/WICG/IntersectionObserver/commit/d4a699cc7a2d12e4e67cd6d1e748bed8bb6e3d8c).
+Earlier preview versions of [Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12156111/) and
+prior to version 58 of [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=713819#c8), the support for
+`isIntersecting` was lacking. This property was added to the spec later and both teams where unable to implement it
+earlier.
 
 #### Performance issues
 
-As the above-mentioned polyfill doesn't perform callback invocation [asynchronously](https://github.com/WICG/IntersectionObserver/issues/225), you might want to decorate your `onChange` callback with a `requestIdleCallback` or `setTimeout` call to avoid a potential performance degradation:
+As the above-mentioned polyfill doesn't perform callback invocation
+[asynchronously](https://github.com/WICG/IntersectionObserver/issues/225), you might want to decorate your `onChange`
+callback with a `requestIdleCallback` or `setTimeout` call to avoid a potential performance degradation:
 
 ```js
-onChange = (entry) => requestIdleCallback(() => this.handleChange(entry));
+onChange = entry => requestIdleCallback(() => this.handleChange(entry));
 ```
 
 ## [**IntersectionObserver**'s Browser Support](https://platform-status.mozilla.org/)
@@ -240,8 +262,10 @@ onChange = (entry) => requestIdleCallback(() => this.handleChange(entry));
     </tr>
 </table>
 
-* [1] [Reportedly available](https://www.chromestatus.com/features/5695342691483648), it didn't trigger the events on initial load and lacks `isIntersecting` until later versions.
-* [2] This feature was implemented in Gecko 53.0 (Firefox 53.0 / Thunderbird 53.0 / SeaMonkey 2.50) behind the preference `dom.IntersectionObserver.enabled`.
+* [1][reportedly available](https://www.chromestatus.com/features/5695342691483648), it didn't trigger the events on
+  initial load and lacks `isIntersecting` until later versions.
+* [2] This feature was implemented in Gecko 53.0 (Firefox 53.0 / Thunderbird 53.0 / SeaMonkey 2.50) behind the
+  preference `dom.IntersectionObserver.enabled`.
 
 ### Using polyfill
 
@@ -264,8 +288,11 @@ onChange = (entry) => requestIdleCallback(() => this.handleChange(entry));
 
 We'd love your help on creating React Intersection Observer!
 
-Before you do, please read our [Code of Conduct](.github/CODE_OF_CONDUCT.md) so you know what we expect when you contribute to our projects.
+Before you do, please read our [Code of Conduct](.github/CODE_OF_CONDUCT.md) so you know what we expect when you
+contribute to our projects.
 
-Our [Contributing Guide](.github/CONTRIBUTING.md) tells you about our development process and what we're looking for, gives you instructions on how to issue bugs and suggest features, and explains how you can build and test your changes.
+Our [Contributing Guide](.github/CONTRIBUTING.md) tells you about our development process and what we're looking for,
+gives you instructions on how to issue bugs and suggest features, and explains how you can build and test your changes.
 
-**Haven't contributed to an open source project before?** No problem! [Contributing Guide](.github/CONTRIBUTING.md) has you covered as well.
+**Haven't contributed to an open source project before?** No problem! [Contributing Guide](.github/CONTRIBUTING.md) has
+you covered as well.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,17 +2,20 @@
 
 Welcome to the code examples section!
 
-Here you'll find usage examples and recipes. For a full list of examples, take a look in our [storybook page](https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples).
+Here you'll find usage examples and recipes. For a full list of examples, take a look in our
+[storybook page](https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples).
 
 * [Basic usage on Window](https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples&selectedStory=Window)
 * [Usage within a scroller/frame](https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples&selectedStory=Frame)
 * [Using thresholds](https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples&selectedStory=Thresholds)
 * [Using the rootMargin option](https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples&selectedStory=Margin)
-* [Using the onlyOnce option](https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples&selectedStory=Once)
+* [Unobserving the target after an intersection](https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples&selectedStory=Once)
 
 ## Recipes
 
-Here you [will find useful code snippets](https://researchgate.github.io/react-intersection-observer/?selectedKind=Recipes) to common situations that can be approached with ReactIntersectionObserver:
+Here you
+[will find useful code snippets](https://researchgate.github.io/react-intersection-observer/?selectedKind=Recipes) to
+common situations that can be approached with ReactIntersectionObserver:
 
 * [Higher Order Component](docs/components/HigherOrderComponent/)
 * [Tracking Ad Impressions](docs/components/ImpressionTracking/)
@@ -23,11 +26,13 @@ Here you [will find useful code snippets](https://researchgate.github.io/react-i
 Yes, of course!
 
 1. Fork the code repo.
-2. Create your new recipe in the correct subfolder within `docs/docs/components/` (create a new folder if it doesn't already exist).
+2. Create your new recipe in the correct subfolder within `docs/docs/components/` (create a new folder if it doesn't
+   already exist).
 3. Make sure you have included a README as well as your source file.
 4. Submit a PR.
 
-_If you haven't yet, please read our [contribution guidelines](https://github.com/researchgate/react-intersection-observer/blob/master/.github/CONTRIBUTING.md)._
+_If you haven't yet, please read our
+[contribution guidelines](https://github.com/researchgate/react-intersection-observer/blob/master/.github/CONTRIBUTING.md)._
 
 ### What license are the recipes released under?
 
@@ -35,4 +40,5 @@ By default, all newly submitted code is licensed under the MIT license.
 
 ### How else can I contribute?
 
-Recipes don't always have to be code - great documentation, tutorials, general tips and even general improvements to our examples folder are greatly appreciated.
+Recipes don't always have to be code - great documentation, tutorials, general tips and even general improvements to our
+examples folder are greatly appreciated.

--- a/docs/docs/components/OnlyOnce/OnlyOnce.js
+++ b/docs/docs/components/OnlyOnce/OnlyOnce.js
@@ -11,7 +11,10 @@ export default class OnlyOnce extends Component {
         visibility: 'hidden',
     };
 
-    handleChange = event => {
+    handleChange = (event, unobserve) => {
+        if (event.isIntersecting) {
+            unobserve();
+        }
         storyBookAction(event);
         this.setState({
             visibility: event.isIntersecting ? 'visible' : 'invisible',
@@ -23,7 +26,7 @@ export default class OnlyOnce extends Component {
             <div>
                 <div className={`header ${this.state.visibility}`}>{this.state.visibility}</div>
                 <div className="body">
-                    <Observer onChange={this.handleChange} onlyOnce={true}>
+                    <Observer onChange={this.handleChange}>
                         <div className={`box ${this.state.visibility}`} />
                     </Observer>
                 </div>

--- a/docs/docs/components/OnlyOnce/README.md
+++ b/docs/docs/components/OnlyOnce/README.md
@@ -1,33 +1,39 @@
-The option `onlyOnce` applied to the component will only trigger the event one time: when the target detects `isIntersecting` is truthy. This is specially useful when you need a _disposable observer_, and you need to prevent re-rendering the element later:
+_Use the second argument of `onChange(event, unobserve)` to customize how you prefer to stop observing the target. You
+can also set the prop `disabled=true` in the `<Observer>` element to achieve the same effect._
+
+**Deprecated**: ~~The option `onlyOnce` applied to the component will only trigger the event one time: when the target
+detects `isIntersecting` is truthy. This is specially useful when you need a _disposable observer_, and you need to
+prevent re-rendering the element later:~~
 
 ```jsx
 import React, { Component } from 'react';
 import Observer from '@researchgate/react-intersection-observer';
 
 export default class OnlyOnce extends Component {
-  state = {
-    visibility: 'hidden',
-  };
+    state = {
+        visibility: 'hidden',
+    };
 
-  handleChange = event => {
-    this.setState({
-      visibility: event.isIntersecting ? 'visible' : 'invisible',
-    });
-  };
+    handleChange = (event, unobserve) => {
+        if (event.isIntersecting) {
+            unobserve();
+        }
+        this.setState({
+            visibility: event.isIntersecting ? 'visible' : 'invisible',
+        });
+    };
 
-  render() {
-    return (
-      <div>
-        <div className={`header ${this.state.visibility}`}>
-          {this.state.visibility}
-        </div>
-        <div className="body">
-          <Observer onChange={this.handleChange} onlyOnce>
-            <div className={`box ${this.state.visibility}`} />
-          </Observer>
-        </div>
-      </div>
-    );
-  }
+    render() {
+        return (
+            <div>
+                <div className={`header ${this.state.visibility}`}>{this.state.visibility}</div>
+                <div className="body">
+                    <Observer onChange={this.handleChange}>
+                        <div className={`box ${this.state.visibility}`} />
+                    </Observer>
+                </div>
+            </div>
+        );
+    }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@storybook/addon-knobs": "^3.4.4",
     "invariant": "^2.2.2",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "warning": "^3.0.0"
   },
   "devDependencies": {
     "@researchgate/babel-preset-rg": "^1.0.1",

--- a/src/IntersectionObserver.js
+++ b/src/IntersectionObserver.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import invariant from 'invariant';
+import warning from 'warning';
 import IntersectionObserverContainer from './IntersectionObserverContainer';
 import { isDOMTypeElement, shallowCompareOptions } from './utils';
 
@@ -101,7 +102,7 @@ export default class IntersectionObserver extends React.Component {
     }
 
     handleChange = event => {
-        this.props.onChange(event);
+        this.props.onChange(event, this.unobserve);
 
         if (this.props.onlyOnce) {
             // eslint-disable-next-line no-undef
@@ -115,6 +116,10 @@ export default class IntersectionObserver extends React.Component {
                 this.unobserve();
             }
         }
+        warning(
+            !this.props.hasOwnProperty('onlyOnce'),
+            'ReactIntersectionObserver: [deprecation] Use the second argument of onChange to unobserve a target instead of onlyOnce. This prop will be removed in the next major version.',
+        );
     };
 
     handleNode = node => {
@@ -134,11 +139,11 @@ export default class IntersectionObserver extends React.Component {
         IntersectionObserverContainer.observe(this);
     }
 
-    unobserve() {
+    unobserve = () => {
         if (this.target != null) {
             IntersectionObserverContainer.unobserve(this);
         }
-    }
+    };
 
     reobserve() {
         this.unobserve();

--- a/src/__tests__/IntersectionObserver.spec.js
+++ b/src/__tests__/IntersectionObserver.spec.js
@@ -291,6 +291,7 @@ describe('callback', () => {
 
 describe('handleChange', () => {
     test('should throw with `onlyOnce` if entry lacks `isIntersecting`', () => {
+        global.spyOn(console, 'error'); // suppress deprecation warning
         const component = (
             <IntersectionObserver onChange={noop} onlyOnce={true}>
                 <span />
@@ -310,6 +311,7 @@ describe('handleChange', () => {
     });
 
     test('should unobserve with `onlyOnce` if `isIntersecting` is true', () => {
+        global.spyOn(console, 'error'); // suppress deprecation warning
         const component = (
             <IntersectionObserver onChange={noop} onlyOnce={true}>
                 <span />
@@ -332,6 +334,7 @@ describe('handleChange', () => {
     });
 
     test('should not unobserve with `onlyOnce` if `isIntersecting` is false', () => {
+        global.spyOn(console, 'error'); // suppress deprecation warning
         const component = (
             <IntersectionObserver onChange={noop} onlyOnce={true}>
                 <span />
@@ -351,6 +354,29 @@ describe('handleChange', () => {
         instance.handleChange(entry);
 
         expect(spy).not.toBeCalled();
+    });
+
+    test('should warn about the deprecation of `onlyOnce`', () => {
+        const component = (
+            <IntersectionObserver onChange={noop} onlyOnce={true}>
+                <span />
+            </IntersectionObserver>
+        );
+        const spy = global.spyOn(console, 'error');
+        const instance = renderer.create(component, { createNodeMock: () => target }).getInstance();
+        const boundingClientRect = {};
+        const intersectionRect = {};
+        const entry = new IntersectionObserverEntry({
+            target,
+            boundingClientRect,
+            intersectionRect,
+        });
+        entry.isIntersecting = true;
+
+        instance.handleChange(entry);
+
+        expect(spy).toBeCalled();
+        expect(spy.calls.first().args[0]).toContain('deprecation');
     });
 
     describe('disabled', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,6 @@ interface Props {
     root?: string | Element | null;
     rootMargin?: string;
     threshold?: number | number[];
-    onlyOnce?: boolean;
     disabled?: boolean;
-    onChange: (entry: IntersectionObserverEntry) => void;
+    onChange: (entry: IntersectionObserverEntry, unobserve: () => void) => void;
 }

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import Observer from '..';
 
-const noop = () => {};
+const noop = (event, unobserve) => {
+    unobserve();
+};
 const Component = () => <span />;
 
 <Observer threshold={1} disabled={false} root="#foo" rootMargin="10px" onChange={noop}>
     <span style={{ height: 1, display: 'block' }} />
 </Observer>;
 
-<Observer threshold={[0.5, 1]} onlyOnce root={document.body} onChange={noop}>
+<Observer threshold={[0.5, 1]} root={document.body} onChange={noop}>
     <Component />
 </Observer>;


### PR DESCRIPTION
Fixes issue #32:

- Adds deprecation warning to the prop `onlyOnce`
- Provide a second argument to `onChange(event, unobserve)` to let the implementor decide

The reasoning behind having `unobserve` is to avoid setting the state on a parent component in order to apply `disabled=true` (which is still the primary approach). This applies to cases where it's either too cumbersome or implies a potential performance loss due to re-rendering. Though performance optimizations on React components are always possible in different ways, sometimes a single callback call is more convenient.