### PR TITLE
chore: move @storybook/addon-knobs to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/researchgate/react-intersection-observer/issues"
   },
   "dependencies": {
-    "@storybook/addon-knobs": "^3.4.4",
     "invariant": "^2.2.2",
     "prop-types": "^15.6.0",
     "warning": "^3.0.0"
@@ -16,6 +15,7 @@
     "@researchgate/babel-preset-rg": "^1.0.1",
     "@researchgate/eslint-config-rg-react": "^2.0.0",
     "@storybook/addon-actions": "^3.2.16",
+    "@storybook/addon-knobs": "^3.4.4",
     "@storybook/addon-options": "^3.2.16",
     "@storybook/react": "^3.2.16",
     "babel-cli": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,10 +95,10 @@
     uuid "^3.1.0"
 
 "@storybook/addon-knobs@^3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.4.4.tgz#96043d68ac382084a9e9d208a084fe58e968377f"
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.4.5.tgz#6ac34c1845b0db6683455e1edbe15993490fc18b"
   dependencies:
-    "@storybook/components" "3.4.4"
+    "@storybook/components" "3.4.5"
     babel-runtime "^6.26.0"
     deep-equal "^1.0.1"
     global "^4.3.2"
@@ -139,9 +139,9 @@
   version "3.2.16"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.2.16.tgz#07d8686328c0bb885aa8b69254fcf0745d22a620"
 
-"@storybook/components@3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.4.4.tgz#272bcbdb2ac28583de049f75352f9eec76835641"
+"@storybook/components@3.4.5":
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.4.5.tgz#02653ba562e3678eab3adbc31b012eae4fbe61dc"
   dependencies:
     glamor "^2.20.40"
     glamorous "^4.12.1"
@@ -2579,8 +2579,8 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
     cssom "0.3.x"
 
 csstype@^2.2.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.1.tgz#654231d1ddddfc3eb93da281a1144e7c14fc0bdc"
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.2.tgz#4534308476ceede8fbe148b9b99f9baf1c80fa06"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Hello 👋 

I moved `@storybook/addon-knobs` to devDeps to avoid missing peerDeps error when we add this package

<img width="1034" alt="screen shot 2018-05-25 at 10 43 14" src="https://user-images.githubusercontent.com/2802867/40535120-7e43933a-6008-11e8-9ca1-0c570418e5e0.png">
