### PR TITLE
move storage above getPooled; replace for...of with while

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Single React component or element that is used as the target (observable).
 * Changes happen asynchronously, similar to the way `requestIdleCallback` works.
 * Although you can consider callbacks immediate - always below 1 second - you can also get an immediate response on an
   element's visibility with `observer.takeRecords()`.
-* The primitives _Map_, _Set_, and _Symbol_ are required and won't be transpiled by default. Consider using a polyfill
+* The primitives `Map` an `Set` are required. You may need to include a polyfill
   for browsers lacking ES2015 support. If you're using babel, include `"babel-polyfill"` somewhere to your codebase.
 
 ## Polyfill

--- a/src/IntersectionObserverContainer.js
+++ b/src/IntersectionObserverContainer.js
@@ -1,13 +1,16 @@
 import { parseRootMargin, shallowCompareOptions } from './utils';
 
+export const storage = new Map();
+
 export function getPooled(options = {}) {
     const root = options.root || null;
     const rootMargin = parseRootMargin(options.rootMargin);
     const threshold = Array.isArray(options.threshold)
         ? options.threshold
         : [typeof options.threshold !== 'undefined' ? options.threshold : 0];
-    // eslint-disable-next-line no-restricted-syntax
-    for (const observer of storage.keys()) {
+    const observers = storage.keys();
+    let observer;
+    while ((observer = observers.next().value)) {
         const unmatched = [
             [root, observer.root],
             [rootMargin, observer.rootMargin],
@@ -21,8 +24,6 @@ export function getPooled(options = {}) {
     return null;
 }
 
-export const storage = new Map();
-
 /**
  * If instances of a class can be reused because the options map,
  * we avoid creating instances of Intersection Observer by reusing them.
@@ -35,8 +36,9 @@ export default class IntersectionObserverContainer {
     static findElement(entry, observer) {
         const elements = storage.get(observer);
         if (elements) {
-            // eslint-disable-next-line no-restricted-syntax
-            for (const element of elements.values()) {
+            const values = elements.values();
+            let element;
+            while ((element = values.next().value)) {
                 if (element.target === entry.target) {
                     return element;
                 }


### PR DESCRIPTION
fixes #36

- Moved `storage` above `getPooled` to fix a linting error about "no use before define"
- Replaced both instances of `for...of` with `while`

All tests pass. Double checked that the desired early bail worked as expected.