### PR TITLE
chore: Update warning package to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "invariant": "^2.2.2",
     "prop-types": "^15.6.0",
-    "warning": "^3.0.0"
+    "warning": "^4.0.2"
   },
   "devDependencies": {
     "@researchgate/babel-preset-rg": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7513,6 +7513,13 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
+warning@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
+  integrity sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==
+  dependencies:
+    loose-envify "^1.0.0"
+
 watch@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"


### PR DESCRIPTION
It's a major version bump, but I don't believe that the public API has changed, based on [the `warning` changelog](https://github.com/BerkeleyTrue/warning/blob/master/CHANGELOG.md).

Locally all the tests pass and this looked good to me.