### PR TITLE
children props should be typed as `ReactNode`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 interface Props {
-    children: React.ReactElement<any> | null | undefined;
+    children: React.ReactNode;
     root?: string | Element | null;
     rootMargin?: string;
     threshold?: number | number[];


### PR DESCRIPTION
ref. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/41fe335d209b4cd46dedafd1a91849d7fec6880d/types/react/index.d.ts#L1218-L1222

<!--- Provide a general summary of your changes in the Title above -->

## Description

`children` props of React Components should have type of `React.ReactNode`.

## Motivation and context

`children` of React Component may not only be Component but can be another forms, such as text node or else. 

FYI: definition of `Props` type in [@types/react](https://www.npmjs.com/package/@types/react) also types `children` as `ReactNode`.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/41fe335d209b4cd46dedafd1a91849d7fec6880d/types/react/index.d.ts#L1218-L1222

## How has this been tested?

Not tested well, but I think this change will not break anything.

## Screenshots (if relevant):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I think this is not breaking change because type `React.Node` accepts `React.Component`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed