### PR TITLE
Lower required Node.js version to 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.1",
   "author": "Luis Merino <mail@luismerino.name>",
   "engines": {
-    "node": ">=10.0.0"
+    "node": "^8.10.0 || >=9.10.0"
   },
   "bugs": {
     "url": "https://github.com/researchgate/react-intersection-observer/issues"


### PR DESCRIPTION
Thanks for taking the time to file a pull request with us.
Please take a moment to provide the following details:

Node.js 8 is still in maintenance and it's used in services like Firebase. This package works with Node.js 8.16.2 without any problem, the `engine` requirement seems to be related only to build tools (it was introduced in https://github.com/researchgate/react-intersection-observer/commit/fff9c526690e84c85c3f3d956b629e09e3bebde6)

## Description
Restore previous Node.js requirements - ^8.10 and >9.10.

**Unfortunatelly, Node.js 10.x is required for tests. Maybe the engine requirements might be lowered in package.json right before publishing to npm?**

## Motivation and context

Node.js 8 is still in maintanence LTS period.

## How has this been tested?

I installed the package locally and it works fine.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed