### PR TITLE
fix(Storybook): Add empty theme option

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,4 @@
-import { configure } from '@storybook/react';
+import { configure, addParameters } from '@storybook/react';
 import { setOptions } from '@storybook/addon-options';
 
 setOptions({
@@ -6,5 +6,7 @@ setOptions({
     url: 'https://github.com/researchgate/react-intersection-observer',
     downPanelInRight: true,
 });
+
+addParameters({ options: { theme: {} } });
 
 configure(() => require('../docs/docs/index.js'), module);


### PR DESCRIPTION
## Description
This prevents a TypeError caused by storybook-readme

## Motivation and context
This seems like it should be unnecessary, and may be fixed in a future storybook-readme release. However, the change is very minimal, and is an acceptable quick fix IMO.

Closes #85

## How has this been tested?
This change fixed Storybook locally for me.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed