### PR TITLE
docs: Include reference to minimum node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ all the imperative parts for you.
 npm install --save @researchgate/react-intersection-observer
 ```
 
-Usage:
+> :warning: **Please make sure you have the minimum node version installed** (as defined [in the package.json](https://github.com/researchgate/react-intersection-observer/blob/master/package.json#L6-L7))
+> 
+> Otherwise you run into this build error:
+>
+> `The engine "node" is incompatible with this module. Expected version ">=10.18.1". Got "10.15.3"`
+
+## Usage
 
 ```jsx
 import React from 'react';


### PR DESCRIPTION
Addressing a comment in #166 this change makes sure users are aware of a minimum version of node and how to find out which one is currently required.

Thanks for taking the time to file a pull request with us.
