### PR TITLE
fix(observer): fix of reobserve doesn't add observer to map

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -78,6 +78,9 @@ export function createObserver(
 }
 
 export function observeElement(element: Instance) {
+  if (element.observer && !observerElementsMap.has(element.observer)) {
+    observerElementsMap.set(element.observer, new Set<Instance>());
+  }
   observerElementsMap.get(element.observer)?.add(element);
   element.observer!.observe(element.target!);
 }

--- a/test/unit/observer.spec.js
+++ b/test/unit/observer.spec.js
@@ -194,4 +194,20 @@ describe('findObserverElement', () => {
         expect(instance1).toEqual(entry1);
         expect(instance2).toEqual(entry2);
     });
+
+    test('two subsequent createObserver calls should not produce two observers', () => {
+        const observer1 = createObserver();
+        const observer2 = createObserver();
+        expect(observer1).toEqual(observer2);
+    });
+
+    test('observing element should add target to observerElementsMap even if there is no such observer key', () => {
+        const observer = createObserver();
+        const entry = { observer, target: target1 };
+        observeElement(entry);
+        unobserveElement(entry, entry.target);
+        observeElement(entry);
+        const instance = findObserverElement(observer, entry);
+        expect(instance).toEqual(entry);
+    });
 });


### PR DESCRIPTION
## Description

Essentially i'm bringing back part of the code deleted in #153, namely https://github.com/researchgate/react-intersection-observer/pull/153/files#diff-44cb04e2627c3ab84281b41d14880e5e822437f19144e8c14a6c95f7f7fa14bbL72

## Motivation and context

When new element already holds a ref to an observer
and the previous element (that used the same observer) unobserves,
it creates a broken state when that observer is deleted from map,
but new element holds that ref and thinks it's ok to observe

Possibly fixes #155 

## How has this been tested?

I tested this change on our usecase and also added tests to not to break this and #153 in the future

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed